### PR TITLE
fix: ensure images are loaded when print pdf

### DIFF
--- a/packages/mercury-ui/src/components/presentation/all-slides-presentation.tsx
+++ b/packages/mercury-ui/src/components/presentation/all-slides-presentation.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, useEffect } from "react"
+import { type FC, type ReactNode, useEffect, useRef } from "react"
 import { useLocation } from "wouter"
 import { useSearchParams } from "../../hooks/use-search-params"
 
@@ -12,13 +12,56 @@ export const AllSlidesPresentation: FC<AllSlidesPresentationProps> = ({
   const search = useSearchParams()
   const [_, navigate] = useLocation()
 
+  const containerRef = useRef<HTMLDivElement>(null)
+  const hasPrinted = useRef(false)
+
   useEffect(() => {
-    if (search.get("print") === "true") {
+    if (search.get("print") !== "true" || !containerRef.current) return
+
+    const print = () => {
+      if (hasPrinted.current) return
       window.print()
+      hasPrinted.current = true
       const from = search.get("from") ?? "/"
       navigate(from)
     }
+
+    const images = containerRef.current.querySelectorAll("img")
+    const totalImages = images.length
+
+    if (totalImages === 0) {
+      print()
+      return
+    }
+
+    let loadedImages = 0
+    const handleImageLoad = () => {
+      loadedImages += 1
+      if (loadedImages === totalImages) {
+        print()
+      }
+    }
+
+    for (const image of images) {
+      if (image.complete) {
+        handleImageLoad()
+      } else {
+        image.addEventListener("load", handleImageLoad)
+        image.addEventListener("error", handleImageLoad)
+      }
+    }
+
+    return () => {
+      for (const image of images) {
+        image.removeEventListener("load", print)
+        image.removeEventListener("error", print)
+      }
+    }
   }, [search, navigate])
 
-  return <div className="mx-auto flex w-fit flex-col gap-0">{children}</div>
+  return (
+    <div className="mx-auto flex w-fit flex-col gap-0" ref={containerRef}>
+      {children}
+    </div>
+  )
 }


### PR DESCRIPTION
This pull request introduces changes to the `AllSlidesPresentation` component in the `mercury-ui` package to improve the printing functionality. The key modifications include adding references to track image loading and ensuring that the print operation only occurs after all images have loaded.

Improvements to printing functionality:

* [`packages/mercury-ui/src/components/presentation/all-slides-presentation.tsx`](diffhunk://#diff-ea0fa8faf05729d258f2d1e56819d1cab2fd7c34465265d8e23f706a4c401eaeL1-R1): Added `useRef` to track the container and a flag to prevent multiple print calls. Introduced logic to wait for all images to load before triggering the print operation. [[1]](diffhunk://#diff-ea0fa8faf05729d258f2d1e56819d1cab2fd7c34465265d8e23f706a4c401eaeL1-R1) [[2]](diffhunk://#diff-ea0fa8faf05729d258f2d1e56819d1cab2fd7c34465265d8e23f706a4c401eaeR15-R66)