### PR TITLE
chore(ci): Refactor CI to separate type check step and add dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build
         run: bun run build
-      - name: Type check
-        run: bun run typecheck
 
   test:
     runs-on: ubuntu-22.04
@@ -40,3 +38,14 @@ jobs:
         uses: ./.github/actions/setup
       - name: Test
         run: bun run test:ci
+
+  typecheck:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Type check
+        run: bun run typecheck

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,7 @@
       "cache": false
     },
     "typecheck": {
+      "dependsOn": ["build"],
       "cache": false
     }
   }


### PR DESCRIPTION
Move the type check job to its own step in the CI pipeline and establish a dependency on the build step to ensure proper execution order.