### PR TITLE
fix: Fix Control Menu stories with virtual routing support

### DIFF
--- a/packages/mercury-ui/src/components/control-menu/control-menu.stories.tsx
+++ b/packages/mercury-ui/src/components/control-menu/control-menu.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { Router } from "wouter"
-
+import { withVirtualRouting } from "../../storybook/virtual-routing-decorator"
 import { ControlMenu } from "./control-menu"
 
 const meta = {
@@ -19,11 +18,24 @@ export const Default: Story = {
   args: {
     slidesLength: 5,
   },
-  decorators: [
-    (Story) => (
-      <Router hook={() => ["/0", () => {}]}>
-        <Story />
-      </Router>
-    ),
-  ],
+  decorators: [withVirtualRouting({ initialPath: "/0" })],
+}
+
+export const WithDifferentStartIndex: Story = {
+  args: {
+    slidesLength: 10,
+  },
+  decorators: [withVirtualRouting({ initialPath: "/3" })],
+}
+
+export const WithRouteParameters: Story = {
+  args: {
+    slidesLength: 7,
+  },
+  parameters: {
+    virtualRouting: {
+      initialPath: "/2",
+    },
+  },
+  decorators: [withVirtualRouting()],
 }

--- a/packages/mercury-ui/src/components/control-menu/control-menu.stories.tsx
+++ b/packages/mercury-ui/src/components/control-menu/control-menu.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { Router } from "wouter"
 
 import { ControlMenu } from "./control-menu"
 
@@ -16,6 +17,13 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    slidesLength: 0,
+    slidesLength: 5,
   },
+  decorators: [
+    (Story) => (
+      <Router hook={() => ["/0", () => {}]}>
+        <Story />
+      </Router>
+    ),
+  ],
 }

--- a/packages/mercury-ui/src/storybook/virtual-routing-decorator.tsx
+++ b/packages/mercury-ui/src/storybook/virtual-routing-decorator.tsx
@@ -21,7 +21,6 @@ export const withVirtualRouting = (
       ...context.parameters?.virtualRouting,
     }
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [currentPath, setCurrentPath] = useState(initialPath)
 
     const virtualLocationHook = (): [string, (path: string) => void] => [

--- a/packages/mercury-ui/src/storybook/virtual-routing-decorator.tsx
+++ b/packages/mercury-ui/src/storybook/virtual-routing-decorator.tsx
@@ -1,0 +1,43 @@
+import type { Decorator } from "@storybook/react-vite"
+import { useState } from "react"
+import { Router } from "wouter"
+
+export type VirtualRoutingOptions = {
+  initialPath?: string
+  basePath?: string
+}
+
+/**
+ * Virtual routing decorator for Storybook that provides Wouter routing context
+ * without depending on the actual browser URL.
+ * Uses a custom location hook to provide virtual routing functionality.
+ */
+export const withVirtualRouting = (
+  options: VirtualRoutingOptions = {},
+): Decorator => {
+  return (Story, context) => {
+    const { initialPath = "/", basePath = "" } = {
+      ...options,
+      ...context.parameters?.virtualRouting,
+    }
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [currentPath, setCurrentPath] = useState(initialPath)
+
+    const virtualLocationHook = (): [string, (path: string) => void] => [
+      basePath + currentPath,
+      (newPath: string) => {
+        const pathWithoutBase = newPath.startsWith(basePath)
+          ? newPath.slice(basePath.length)
+          : newPath
+        setCurrentPath(pathWithoutBase)
+      },
+    ]
+
+    return (
+      <Router hook={virtualLocationHook}>
+        <Story />
+      </Router>
+    )
+  }
+}


### PR DESCRIPTION
Update the Default story to include `slidesLength` and add a virtual routing decorator for Storybook, enabling better routing context simulation in stories.